### PR TITLE
Added missing MQTT username and password options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The following MQTT payload should be sent:
 
 These protocol, pulselength and binary variables can be sniffed as described in [Obtaining RF codes](#obtaining-rf-codes).
 
+Remember to modify lines 12 & 13 with your MQTT broker's username and password, or uncomment line 135 and comment line 136 if you have no credentials needed for your MQTT broker.
+
 For persistency, the _retain-flag_ can be set such that the codes are re-sent when the ESP8266 is rebooted.
 
 ## Code setup

--- a/bridge.ino
+++ b/bridge.ino
@@ -9,7 +9,8 @@
 #define WIFI_PASSWORD "..."
 
 #define MQTT_TOPIC "switch/rf/+"
-
+const char* mqttUser = "YourMQTTUserName";
+const char* mqttPassword = "YourMQTTPassword";
 #define TX_PIN 4 // Receiver on GPIO4 / D2.
 #define TX_REPEAT 15
 
@@ -130,9 +131,9 @@ void reconnect() {
   while (!client.connected()) {
     Serial.print("Attempting MQTT connection...");
     // Attempt to connect
-    // If you do not want to use a username and password, change next line to
+    // If you do not want to use a username and password, change next line to just
     // if (client.connect("ESP8266Client")) {
-    if (client.connect("ESP8266Client")) {
+    if (client.connect("ESP8266Client", mqttUser, mqttPassword)) {
       Serial.println("connected");
       // Subscribe to the topic
       client.subscribe(MQTT_TOPIC);


### PR DESCRIPTION

If you have an MQTT broker that requires a username and password, you will need these changes to connect properly.

Change lines 12 & 13 to match your MQTT broker's needs.